### PR TITLE
Fix blurry font rendering

### DIFF
--- a/web/pdf_page_view.js
+++ b/web/pdf_page_view.js
@@ -793,6 +793,7 @@ class PDFPageView extends BasePDFPageView {
     this.#computeScale();
 
     if (this.canvas) {
+      this.canvas.style = "";
       const onlyCssZoom =
         this.#hasRestrictedScaling && this.#needsRestrictedScaling;
       const postponeDrawing = drawingDelay >= 0 && drawingDelay < 1000;
@@ -1152,6 +1153,9 @@ class PDFPageView extends BasePDFPageView {
 
     const recordImages =
       this.imagesRightClickMinSize !== -1 && !this.imageCoordinates;
+
+    canvas.style.width = floorToDivide(calcRound(width), sfx[1]) + "px";
+    canvas.style.height = floorToDivide(calcRound(height), sfy[1]) + "px";
 
     // Rendering area
     const transform = outputScale.scaled


### PR DESCRIPTION
This reapplies the changes from the following commits, which no longer exist in the git history:

* https://github.com/zotero/pdf.js/commit/7f547333ca551aff1b89414452df43ba60da07b0
* https://github.com/zotero/pdf.js/commit/67a1769bdaa0e89a6e239fcbaa5bf72b845223a0

These fixed the blurry font rendering issue in zotero versions 7.0.15 and 7.1-beta.41+355c61e6d.  However, these patches were later dropped when pdf.js was updated and hence the issue reappeared.

Fixes https://forums.zotero.org/discussion/120296/blurry-pdf-at-some-zoom-levels-in-version-7-0-11